### PR TITLE
Autogen thumbnail bugfix

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,53 @@
+from __future__ import unicode_literals
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from wagtail.tests.utils import WagtailTestUtils
+
+from tests.utils import create_test_video_file
+from wagtailvideos.models import Video
+
+
+class TestVideoModel(WagtailTestUtils, TestCase):
+
+    @override_settings(WAGTAILVIDEOS_CREATE_FILE_HASH=True)
+    def test_create_file_hash(self):
+        video_file = create_test_video_file()
+        video = Video(
+            file=video_file
+        )
+        video.save()
+        assert video.file_hash
+        assert video.file_size
+        current_hash = video.file_hash
+        new_video_file = create_test_video_file(file_name='big_buck_bunny.mp4')
+        video.file = new_video_file
+        video.save()
+        assert video.file_hash != current_hash
+
+    def test_create_file_hash_disabled(self):
+        video_file = create_test_video_file()
+        video = Video(
+            file=video_file
+        )
+        video.save()
+        assert not video.file_hash
+        assert video.file_size
+
+    def test_thumbnail(self):
+        # Creating a video with no provided thumbnail should auto-create one
+        video_file = create_test_video_file()
+        video = Video(
+            file=video_file
+        )
+        video.save()
+        assert video.thumbnail
+        # Change the thumbnail to a manually provided one
+        video.thumbnail = SimpleUploadedFile('test.jpg', b'')
+        video.save()
+        # Change the video file, and ensure that our manually provided
+        # thumbnail is still there
+        video_file = create_test_video_file()
+        video.file = video_file
+        video.save()
+        assert video.thumbnail.name == 'original_videos/test.jpg'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from wagtail.tests.utils import WagtailTestUtils
 
 from tests.utils import create_test_video_file
@@ -9,30 +9,6 @@ from wagtailvideos.models import Video
 
 
 class TestVideoModel(WagtailTestUtils, TestCase):
-
-    @override_settings(WAGTAILVIDEOS_CREATE_FILE_HASH=True)
-    def test_create_file_hash(self):
-        video_file = create_test_video_file()
-        video = Video(
-            file=video_file
-        )
-        video.save()
-        assert video.file_hash
-        assert video.file_size
-        current_hash = video.file_hash
-        new_video_file = create_test_video_file(file_name='big_buck_bunny.mp4')
-        video.file = new_video_file
-        video.save()
-        assert video.file_hash != current_hash
-
-    def test_create_file_hash_disabled(self):
-        video_file = create_test_video_file()
-        video = Video(
-            file=video_file
-        )
-        video.save()
-        assert not video.file_hash
-        assert video.file_size
 
     def test_thumbnail(self):
         # Creating a video with no provided thumbnail should auto-create one

--- a/wagtailvideos/ffmpeg.py
+++ b/wagtailvideos/ffmpeg.py
@@ -46,7 +46,7 @@ def get_thumbnail(file_path):
         raise RuntimeError('ffmpeg is not installed')
 
     file_name = os.path.basename(file_path)
-    thumb_name = '{}_thumb{}'.format(os.path.splitext(file_name)[0], '.jpg')
+    thumb_name = '{}_thumb_autogen{}'.format(os.path.splitext(file_name)[0], '.jpg')
 
     try:
         output_dir = tempfile.mkdtemp()

--- a/wagtailvideos/forms.py
+++ b/wagtailvideos/forms.py
@@ -5,7 +5,6 @@ from enumchoicefield.forms import EnumField
 from wagtail.admin import widgets
 from wagtail.admin.forms import (
     BaseCollectionMemberForm, collection_member_permission_formset_factory)
-from wagtail.images.fields import WagtailImageField
 
 from wagtailvideos.fields import WagtailVideoField
 from wagtailvideos.models import MediaFormats, Video, VideoQuality

--- a/wagtailvideos/forms.py
+++ b/wagtailvideos/forms.py
@@ -5,6 +5,7 @@ from enumchoicefield.forms import EnumField
 from wagtail.admin import widgets
 from wagtail.admin.forms import (
     BaseCollectionMemberForm, collection_member_permission_formset_factory)
+from wagtail.images.fields import WagtailImageField
 
 from wagtailvideos.fields import WagtailVideoField
 from wagtailvideos.models import MediaFormats, Video, VideoQuality
@@ -29,6 +30,8 @@ def formfield_for_dbfield(db_field, **kwargs):
     # Check if this is the file field
     if db_field.name == 'file':
         return WagtailVideoField(**kwargs)
+    elif db_field.name == 'thumbnail':
+        return WagtailImageField(**kwargs)
 
     # For all other fields, just call its formfield() method.
     return db_field.formfield(**kwargs)
@@ -55,7 +58,6 @@ def get_video_form(model):
         widgets={
             'tags': widgets.AdminTagWidget,
             'file': forms.FileInput(),
-            'thumbnail': forms.FileInput(),
         })
 
 

--- a/wagtailvideos/forms.py
+++ b/wagtailvideos/forms.py
@@ -30,8 +30,6 @@ def formfield_for_dbfield(db_field, **kwargs):
     # Check if this is the file field
     if db_field.name == 'file':
         return WagtailVideoField(**kwargs)
-    elif db_field.name == 'thumbnail':
-        return WagtailImageField(**kwargs)
 
     # For all other fields, just call its formfield() method.
     return db_field.formfield(**kwargs)

--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -333,7 +333,7 @@ def video_saved(sender, instance, **kwargs):
 
     if has_changed or not filled_out:
         with get_local_file(instance.file) as file_path:
-            if (has_changed and thumbnail_is_autogen) or instance.thumbnail is None:
+            if (has_changed and thumbnail_is_autogen) or not instance.thumbnail:
                 instance.thumbnail = ffmpeg.get_thumbnail(file_path)
 
             if has_changed or instance.duration is None:

--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -329,7 +329,7 @@ def video_saved(sender, instance, **kwargs):
 
     has_changed = instance._initial_file is not instance.file
     filled_out = instance.thumbnail is not None and instance.duration is not None
-    thumbnail_is_autogen = instance.thumbnail is not None and instance.thumbnail.name.endswith('autogen.jpg')
+    thumbnail_is_autogen = instance.thumbnail is not None and instance.thumbnail.name and instance.thumbnail.name.endswith('autogen.jpg')
 
     if has_changed or not filled_out:
         with get_local_file(instance.file) as file_path:

--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -329,9 +329,11 @@ def video_saved(sender, instance, **kwargs):
 
     has_changed = instance._initial_file is not instance.file
     filled_out = instance.thumbnail is not None and instance.duration is not None
+    thumbnail_is_autogen = instance.thumbnail is not None and instance.thumbnail.name.endswith('autogen.jpg')
+
     if has_changed or not filled_out:
         with get_local_file(instance.file) as file_path:
-            if has_changed or instance.thumbnail is None:
+            if (has_changed and thumbnail_is_autogen) or instance.thumbnail is None:
                 instance.thumbnail = ffmpeg.get_thumbnail(file_path)
 
             if has_changed or instance.duration is None:

--- a/wagtailvideos/templates/wagtailvideos/videos/edit.html
+++ b/wagtailvideos/templates/wagtailvideos/videos/edit.html
@@ -1,5 +1,20 @@
-{% extends "wagtailadmin/base.html" %} {% load staticfiles wagtailadmin_tags i18n wagtailvideos_tags %} {% block titletag %}{% blocktrans with title=video.title %}Editing video {{ title }}{% endblocktrans %}{% endblock %} {% block extra_css %}
-<link rel="stylesheet" href="{% static 'wagtailvideos/css/edit-video.css' %}" type="text/css" /> {% endblock %} {% block extra_js %} {{ block.super }} {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
+{% extends "wagtailadmin/base.html" %} {% load staticfiles wagtailadmin_tags i18n wagtailvideos_tags %} {% block titletag %}{% blocktrans with title=video.title %}Editing video {{ title }}{% endblocktrans %}{% endblock %}
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'wagtailvideos/css/edit-video.css' %}" type="text/css" />
+<style>
+input[name="thumbnail-clear"] {
+    margin-top: 25px;
+    display: table;
+}
+label[for="thumbnail-clear_id"] {
+    float: initial;
+    position: relative;
+    top: -15px;
+    left: 25px;
+}
+</style>
+{% endblock %}
+{% block extra_js %} {{ block.super }} {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
 <script>
     $(function() {
         $('#id_tags').tagit({
@@ -17,7 +32,12 @@
         <form action="{% url 'wagtailvideos:edit' video.id %}" method="POST" enctype="multipart/form-data">
             {% csrf_token %}
             <ul class="fields">
-                {% for field in form %} {% if field.name == 'file' %} {% include "wagtailvideos/videos/_file_field_as_li.html" %} {% elif field.is_hidden %} {{ field }} {% else %} {% include "wagtailadmin/shared/field_as_li.html" %} {% endif %} {% endfor %}
+                {% for field in form %}
+                    {% if field.name == 'file' %} {% include "wagtailvideos/videos/_file_field_as_li.html" %}
+                    {% elif field.is_hidden %} {{ field }}
+                    {% else %} {% include "wagtailadmin/shared/field_as_li.html" %} 
+                    {% endif %}
+                {% endfor %}
                 <li>
                     <input type="submit" class="button" value="{% trans 'Save' %}" /> {% if user_can_delete %}
                     <a href="{% url 'wagtailvideos:delete' video.id %}" class="button button-secondary no">{% trans "Delete video" %}</a> {% endif %}


### PR DESCRIPTION
Fixes #31 by retaining thumbnails when a video is updated if it was not originally auto-generated. All other behavior remains intact, except that the file input is now clearable. This would allow users to nullify a custom thumbnail, hence allowing for auto-generation again.