### PR TITLE
Wagtail 2.4+ compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj21-wt25
       python: 3.6
-    - env: TOXENV=py36-dj22-wt25
-      python: 3.6
+    # - env: TOXENV=py36-dj22-wt25
+      # python: 3.6
     - env: TOXENV='flake8,isort'
       python: 3.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 cache: pip
+dist: xenial
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,16 @@ env:
 
 
 python:
-  - 3.4
   - 3.5
   - 3.6
+  - 3.7
 
 env:
-  - DJANGO='111' WAGTAIL='20'
-  - DJANGO='111' WAGTAIL='21'
-  - DJANGO='20' WAGTAIL='20'
-  - DJANGO='20' WAGTAIL='21'
+  - DJANGO='20' WAGTAIL='24'
+  - DJANGO='20' WAGTAIL='25'
+  - DJANGO='21' WAGTAIL='24'
+  - DJANGO='21' WAGTAIL='25'
+  - DJANGO='22' WAGTAIL='25'
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ dist: trusty
 env:
   global:
     - DJANGO_SETTINGS_MODULE="tests.app.settings"
-    - TOX_ENV=
-  matrix:
-    - TOX_ENV=flake8,isort
+
 
 matrix:
   include:
@@ -27,7 +25,9 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj21-wt25
       python: 3.6
-    - env: TOX_ENV='flake8,isort'
+    - env: TOXENV=py36-dj22-wt25
+      python: 3.6
+    - env: TOXENV='flake8,isort'
       python: 3.5
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 env:
   global:
     - DJANGO_SETTINGS_MODULE="tests.app.settings"
+    - TOX_ENV=
   matrix:
     - TOX_ENV=flake8,isort
 
@@ -18,14 +19,6 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj21-wt24
       python: 3.6
-    - env: TOXENV=py37-dj20-wt24
-      python: 3.7
-      sudo: true
-      dist: xenial
-    - env: TOXENV=py37-dj21-wt24
-      python: 3.7
-      dist: xenial
-      sudo: true
     - env: TOXENV=py35-dj20-wt25
       python: 3.5
     - env: TOXENV=py35-dj21-wt25
@@ -34,18 +27,6 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj21-wt25
       python: 3.6
-    - env: TOXENV=py37-dj20-wt25
-      python: 3.7
-      dist: xenial
-      sudo: true
-    - env: TOXENV=py37-dj21-wt25
-      python: 3.7
-      dist: xenial
-      sudo: true
-    - env: TOXENV=py37-dj22-wt25
-      python: 3.7
-      dist: xenial
-      sudo: true
     - env: TOX_ENV='flake8,isort'
       python: 3.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
 python:
   - 3.5
   - 3.6
-  - 3.7
 
 env:
   - DJANGO='20' WAGTAIL='24'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ dist: trusty
 env:
   global:
     - DJANGO_SETTINGS_MODULE="tests.app.settings"
+  matrix:
+    - TOX_ENV=flake8,isort
 
 matrix:
   include:
@@ -18,10 +20,12 @@ matrix:
       python: 3.6
     - env: TOXENV=py37-dj20-wt24
       python: 3.7
+      sudo: true
       dist: xenial
     - env: TOXENV=py37-dj21-wt24
       python: 3.7
       dist: xenial
+      sudo: true
     - env: TOXENV=py35-dj20-wt25
       python: 3.5
     - env: TOXENV=py35-dj21-wt25
@@ -33,12 +37,15 @@ matrix:
     - env: TOXENV=py37-dj20-wt25
       python: 3.7
       dist: xenial
+      sudo: true
     - env: TOXENV=py37-dj21-wt25
       python: 3.7
       dist: xenial
+      sudo: true
     - env: TOXENV=py37-dj22-wt25
       python: 3.7
       dist: xenial
+      sudo: true
     - env: TOX_ENV='flake8,isort'
       python: 3.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,44 @@
 language: python
 cache: pip
-dist: xenial
+dist: trusty
 
 env:
   global:
     - DJANGO_SETTINGS_MODULE="tests.app.settings"
-    - TOX_ENV=
-  matrix:
-    - TOX_ENV=flake8,isort
-
-
-python:
-  - 3.5
-  - 3.6
-
-env:
-  - DJANGO='20' WAGTAIL='24'
-  - DJANGO='20' WAGTAIL='25'
-  - DJANGO='21' WAGTAIL='24'
-  - DJANGO='21' WAGTAIL='25'
-  - DJANGO='22' WAGTAIL='25'
-
 
 matrix:
   include:
+    - env: TOXENV=py35-dj20-wt24
+      python: 3.5
+    - env: TOXENV=py35-dj21-wt24
+      python: 3.5
+    - env: TOXENV=py36-dj20-wt24
+      python: 3.6
+    - env: TOXENV=py36-dj21-wt24
+      python: 3.6
+    - env: TOXENV=py37-dj20-wt24
+      python: 3.7
+      dist: xenial
+    - env: TOXENV=py37-dj21-wt24
+      python: 3.7
+      dist: xenial
+    - env: TOXENV=py35-dj20-wt25
+      python: 3.5
+    - env: TOXENV=py35-dj21-wt25
+      python: 3.5
+    - env: TOXENV=py36-dj20-wt25
+      python: 3.6
+    - env: TOXENV=py36-dj21-wt25
+      python: 3.6
+    - env: TOXENV=py37-dj20-wt25
+      python: 3.7
+      dist: xenial
+    - env: TOXENV=py37-dj21-wt25
+      python: 3.7
+      dist: xenial
+    - env: TOXENV=py37-dj22-wt25
+      python: 3.7
+      dist: xenial
     - env: TOX_ENV='flake8,isort'
       python: 3.5
 
@@ -42,6 +57,4 @@ cache:
     - $HOME/virtualenv
 
 script:
-  # Run tox using either a specific environment from TOX_ENV,
-  # or building one from the environment variables
-  - tox -e "${TOX_ENV:-py${TRAVIS_PYTHON_VERSION/./}-dj${DJANGO}-wt${WAGTAIL}}"
+  - tox

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ html5 compliant codec using ffmpeg.
 Requirements
 ------------
 
--  Wagtail >= 2.0
+-  Wagtail >= 2.4
 -  `ffmpeg <https://ffmpeg.org/>`__
 
 Installing

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/takeflight/wagtailvideos',
 
     install_requires=[
-        'wagtail>=2.0',
+        'wagtail>=2.4',
         'Django>=1.11',
         'django-enumchoicefield==1.1.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         'wagtail>=2.0',
         'Django>=1.11',
-        'django-enumchoicefield==1.0.0',
+        'django-enumchoicefield==1.1.0',
     ],
     extras_require={
         'testing': [

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -20,6 +20,7 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.messages',
     'django.contrib.sessions',
     'django.contrib.staticfiles',
 ]

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -3,15 +3,16 @@ from __future__ import unicode_literals
 import re
 
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import path, re_path
 from django.views.static import serve
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'', include(wagtail_urls)),
+    path('admin/', include(wagtailadmin_urls)),
+    path('', include(wagtail_urls)),
     #  For media serving
-    url(r'^%s(?P<path>.*)$' % re.escape(
+    re_path(r'^%s(?P<path>.*)$' % re.escape(
         settings.MEDIA_URL.lstrip('/')), serve, kwargs={'document_root': settings.MEDIA_ROOT})
 ]

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -315,8 +315,8 @@ class TestVideoChooserView(TestCase, WagtailTestUtils):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'wagtailvideos/chooser/chooser.html')
-        self.assertTemplateUsed(response, 'wagtailvideos/chooser/chooser.js')
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['step'], 'chooser')
 
     def test_search(self):
         response = self.get({'q': "Hello"})
@@ -364,7 +364,8 @@ class TestVideoChooserChosenView(TestCase, WagtailTestUtils):
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'wagtailvideos/chooser/video_chosen.js')
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['step'], 'video_chosen')
 
 
 class TestVideoChooserUploadView(TestCase, WagtailTestUtils):
@@ -378,7 +379,8 @@ class TestVideoChooserUploadView(TestCase, WagtailTestUtils):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailvideos/chooser/chooser.html')
-        self.assertTemplateUsed(response, 'wagtailvideos/chooser/chooser.js')
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['step'], 'chooser')
 
     def test_upload(self):
         response = self.client.post(reverse('wagtailvideos:chooser_upload'), {

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{34,35,36}-dj{110,20}-wt{20,21}
+	py{35,36,37}-dj{20,21}-wt24
+	py{35,36,37}-dj{20,21,22}-wt25
 	# Enforce good style
 	flake8,isort
 
@@ -15,10 +16,11 @@ pip_pre = True
 
 deps =
 	{[base]deps}
-	dj111: Django~=1.11.0
 	dj20: Django~=2.0.0
-	wt20: wagtail~=2.0.0
-	wt21: wagtail~=2.1.0
+	dj21: Django~=2.1.0
+	dj22: Django~=2.2.0
+	wt24: wagtail~=2.4.0
+	wt25: wagtail~=2.5.0
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{35,36}-dj{20,21}-wt24
-	py{35,36}-dj{20,21,22}-wt25
+	py{35,36,37}-dj{20,21}-wt24
+	py{35,36,37}-dj{20,21,22}-wt25
 	# Enforce good style
 	flake8,isort
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{35,36,37}-dj{20,21}-wt24
-	py{35,36,37}-dj{20,21,22}-wt25
+	py{35,36}-dj{20,21}-wt24
+	py{35,36}-dj{20,21,22}-wt25
 	# Enforce good style
 	flake8,isort
 

--- a/wagtailvideos/forms.py
+++ b/wagtailvideos/forms.py
@@ -3,7 +3,7 @@ from django.forms.models import modelform_factory
 from django.utils.translation import ugettext as _
 from enumchoicefield.forms import EnumField
 from wagtail.admin import widgets
-from wagtail.admin.forms import (
+from wagtail.admin.forms.collections import (
     BaseCollectionMemberForm, collection_member_permission_formset_factory)
 
 from wagtailvideos.fields import WagtailVideoField

--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -18,7 +18,7 @@ from django.dispatch.dispatcher import receiver
 from django.forms.utils import flatatt
 from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.text import mark_safe
+from django.utils.html import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from enumchoicefield import ChoiceEnum, EnumChoiceField
 from taggit.managers import TaggableManager

--- a/wagtailvideos/static/wagtailvideos/js/video-chooser-modal.js
+++ b/wagtailvideos/static/wagtailvideos/js/video-chooser-modal.js
@@ -1,5 +1,5 @@
-{% load i18n %}
-function(modal) {
+VIDEO_CHOOSER_MODAL_ONLOAD_HANDLERS = {
+  'chooser': function(modal, jsonData) {
     var searchUrl = $('form.video-search', modal.body).attr('action');
 
     /* currentTag stores the tag currently being filtered on, so that we can
@@ -69,12 +69,10 @@ function(modal) {
                 modal.loadResponseText(response);
             },
             error: function(response, textStatus, errorThrown) {
-                {% trans "Server Error" as error_label %}
-                {% trans "Report this error to your webmaster with the following information:" as error_message %}
-                message = '{{ error_message|escapejs }}<br />' + errorThrown + ' - ' + response.status;
-                $('#upload').append(
-                    '<div class="help-block help-critical">' +
-                    '<strong>{{ error_label|escapejs }}: </strong>' + message + '</div>');
+              message = jsonData['error_message'] + '<br />' + errorThrown + ' - ' + response.status;
+                      $('#upload').append(
+                          '<div class="help-block help-critical">' +
+                          '<strong>' + jsonData['error_label'] + ': </strong>' + message + '</div>');
             }
         });
 
@@ -98,11 +96,13 @@ function(modal) {
         });
         return false;
     });
-
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
-
     /* Add tag entry interface (with autocompletion) to the tag field of the image upload form */
-    $('#id_tags', modal.body).tagit({
-        autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
-    });
+    // $('#id_tags', modal.body).tagit({
+    //     autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
+    // });
+  },
+  'video_chosen': function(modal, jsonData) {
+      modal.respond('videoChosen', jsonData['result']);
+      modal.close();
+  },
 }

--- a/wagtailvideos/static/wagtailvideos/js/video-chooser.js
+++ b/wagtailvideos/static/wagtailvideos/js/video-chooser.js
@@ -7,6 +7,7 @@ function createVideoChooser(id) {
     $('.action-choose', chooserElement).click(function() {
         ModalWorkflow({
             url: window.chooserUrls.videoChooser,
+            onload: VIDEO_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
                 videoChosen: function(videoData) {
                     input.val(videoData.id);

--- a/wagtailvideos/templates/wagtailvideos/chooser/video_chosen.js
+++ b/wagtailvideos/templates/wagtailvideos/chooser/video_chosen.js
@@ -1,4 +1,0 @@
-function(modal) {
-    modal.respond('videoChosen', {{ video_json|safe }});
-    modal.close();
-}

--- a/wagtailvideos/templates/wagtailvideos/videos/edit.html
+++ b/wagtailvideos/templates/wagtailvideos/videos/edit.html
@@ -1,4 +1,10 @@
-{% extends "wagtailadmin/base.html" %} {% load staticfiles wagtailadmin_tags i18n wagtailvideos_tags %} {% block titletag %}{% blocktrans with title=video.title %}Editing video {{ title }}{% endblocktrans %}{% endblock %} {% block extra_css %}
+{% extends "wagtailadmin/base.html" %}
+
+{% load staticfiles wagtailadmin_tags i18n wagtailvideos_tags %}
+
+{% block titletag %}{% blocktrans with title=video.title %}Editing video {{ title }}{% endblocktrans %}{% endblock %}
+
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'wagtailvideos/css/edit-video.css' %}" type="text/css" /> {% endblock %} {% block extra_js %} {{ block.super }} {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
 <script>
     $(function() {
@@ -9,7 +15,11 @@
         });
     });
 </script>
-{% endblock %} {% block content %} {% trans "Editing" as editing_str %} {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=video.title icon="media" %}
+{% endblock %}
+{% block content %}
+{% trans "Editing" as editing_str %}
+
+{% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=video.title icon="media" %}
 
 <div class="row row-flush nice-padding">
 
@@ -17,7 +27,15 @@
         <form action="{% url 'wagtailvideos:edit' video.id %}" method="POST" enctype="multipart/form-data">
             {% csrf_token %}
             <ul class="fields">
-                {% for field in form %} {% if field.name == 'file' %} {% include "wagtailvideos/videos/_file_field_as_li.html" %} {% elif field.is_hidden %} {{ field }} {% else %} {% include "wagtailadmin/shared/field_as_li.html" %} {% endif %} {% endfor %}
+                {% for field in form %}
+                  {% if field.name == 'file' %}
+                    {% include "wagtailvideos/videos/_file_field_as_li.html" %}
+                  {% elif field.is_hidden %}
+                    {{ field }}
+                  {% else %}
+                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                  {% endif %}
+                  {% endfor %}
                 <li>
                     <input type="submit" class="button" value="{% trans 'Save' %}" /> {% if user_can_delete %}
                     <a href="{% url 'wagtailvideos:delete' video.id %}" class="button button-secondary no">{% trans "Delete video" %}</a> {% endif %}
@@ -48,7 +66,9 @@
             <h3 class="label">Create transcode</h3>
             <form action="{% url 'wagtailvideos:create_transcode' video.id %}" method="POST">
                 <ul class="fields">
-                    {% csrf_token %} {% include "wagtailadmin/shared/field_as_li.html" with field=transcode_form.media_format %} {% include "wagtailadmin/shared/field_as_li.html" with field=transcode_form.quality %}
+                    {% csrf_token %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=transcode_form.media_format %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=transcode_form.quality %}
                     <li>
                         <input class="button" type='submit' value="Start" />
                     </li>

--- a/wagtailvideos/templates/wagtailvideos/widgets/video_chooser.html
+++ b/wagtailvideos/templates/wagtailvideos/widgets/video_chooser.html
@@ -3,7 +3,7 @@
 {% block chooser_class %}image-chooser{% endblock %}
 
 {% block chosen_state_view %}
-    <div class="video-thumb">
+    <div class="preview-image">
         {% if video and video.thumbnail %}
             <img src='{{video.thumbnail.url}}' width="165" height="165" class="show-transparency">
         {% else %}

--- a/wagtailvideos/views/chooser.py
+++ b/wagtailvideos/views/chooser.py
@@ -6,6 +6,7 @@ from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.utils import PermissionPolicyChecker, popular_tags_for_model
 from wagtail.core.models import Collection
+from wagtail.images.views.chooser import get_chooser_js_data
 from wagtail.search import index as search_index
 from wagtail.utils.pagination import paginate
 
@@ -22,14 +23,14 @@ def get_video_json(video):
     image chooser panel
     """
 
-    return json.dumps({
+    return {
         'id': video.id,
         'edit_link': reverse('wagtailvideos:edit', args=(video.id,)),
         'title': video.title,
         'preview': {
             'url': video.thumbnail.url if video.thumbnail else '',
         }
-    })
+    }
 
 
 def chooser(request):
@@ -79,7 +80,7 @@ def chooser(request):
 
         paginator, videos = paginate(request, videos, per_page=12)
 
-    return render_modal_workflow(request, 'wagtailvideos/chooser/chooser.html', 'wagtailvideos/chooser/chooser.js', {
+    return render_modal_workflow(request, 'wagtailvideos/chooser/chooser.html', None, {
         'videos': videos,
         'uploadform': uploadform,
         'searchform': searchform,
@@ -87,16 +88,17 @@ def chooser(request):
         'query_string': q,
         'popular_tags': popular_tags_for_model(Video),
         'collections': collections,
-    })
+    }, json_data=get_chooser_js_data())
 
 
 def video_chosen(request, video_id):
     video = get_object_or_404(Video, id=video_id)
 
     return render_modal_workflow(
-        request, None, 'wagtailvideos/chooser/video_chosen.js',
-        {'video_json': get_video_json(video)}
-    )
+        request, None, json_data={
+            'step': 'video_chosen',
+            'result': get_video_json(video)
+        })
 
 
 @permission_checker.require('add')

--- a/wagtailvideos/views/chooser.py
+++ b/wagtailvideos/views/chooser.py
@@ -2,7 +2,7 @@ import json
 
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from wagtail.admin.forms import SearchForm
+from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.utils import PermissionPolicyChecker, popular_tags_for_model
 from wagtail.core.models import Collection

--- a/wagtailvideos/views/chooser.py
+++ b/wagtailvideos/views/chooser.py
@@ -1,5 +1,3 @@
-import json
-
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from wagtail.admin.forms.search import SearchForm
@@ -119,8 +117,10 @@ def chooser_upload(request):
             search_index.insert_or_update_object(video)
 
             return render_modal_workflow(
-                request, None, 'wagtailvideos/chooser/video_chosen.js',
-                {'video_json': get_video_json(video)}
+                request, None, json_data={
+                    'step': 'video_chosen',
+                    'result': get_video_json(video)
+                }
             )
     else:
         form = VideoForm()
@@ -129,6 +129,7 @@ def chooser_upload(request):
     paginator, videos = paginate(request, videos, per_page=12)
 
     return render_modal_workflow(
-        request, 'wagtailvideos/chooser/chooser.html', 'wagtailvideos/chooser/chooser.js',
-        {'videos': videos, 'uploadform': form, 'searchform': searchform}
+        request, 'wagtailvideos/chooser/chooser.html', None,
+        template_vars={'videos': videos, 'uploadform': form, 'searchform': searchform},
+        json_data=get_chooser_js_data()
     )

--- a/wagtailvideos/views/videos.py
+++ b/wagtailvideos/views/videos.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 from wagtail.admin import messages
-from wagtail.admin.forms import SearchForm
+from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.utils import PermissionPolicyChecker, popular_tags_for_model
 from wagtail.core.models import Collection
 from wagtail.search.backends import get_search_backends

--- a/wagtailvideos/wagtail_hooks.py
+++ b/wagtailvideos/wagtail_hooks.py
@@ -1,7 +1,6 @@
 from django.conf.urls import include, url
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.urls import reverse
-from django.utils.html import format_html, format_html_join
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from wagtail.admin.menu import MenuItem
 from wagtail.core import hooks
@@ -19,14 +18,7 @@ def register_admin_urls():
 
 @hooks.register('insert_editor_js')
 def editor_js():
-    js_files = [
-        static('wagtailvideos/js/video-chooser.js'),
-    ]
-    js_includes = format_html_join(
-        '\n', '<script src="{0}"></script>',
-        ((filename, ) for filename in js_files)
-    )
-    return js_includes + format_html(
+    return format_html(
         """
         <script>
             window.chooserUrls.videoChooser = '{0}';

--- a/wagtailvideos/widgets.py
+++ b/wagtailvideos/widgets.py
@@ -30,3 +30,9 @@ class AdminVideoChooser(AdminChooser):
 
     def render_js_init(self, id_, name, value):
         return "createVideoChooser({0});".format(json.dumps(id_))
+
+    class Media:
+        js = [
+            'wagtailvideos/js/video-chooser-modal.js',
+            'wagtailvideos/js/video-chooser.js',
+        ]


### PR DESCRIPTION
Fixes #28 

Updated to use the new wagtail js template for modals introduced in 2.2 outlined [here](https://github.com/wagtail/wagtail/blob/stable/2.2.x/docs/releases/2.2.rst#javascript-templates-in-modal-workflows-are-deprecated)

This is a breaking change for pre-2.2 wagtail installs but easier to maintain going forward than supporting both the old and new methods
