### PR TITLE
Version number comparisons for conditional imports (wagtail 2.10 > 2.7)

### DIFF
--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import tempfile
 import threading
+from packaging import version
 from contextlib import contextmanager
 
 import wagtail
@@ -29,7 +30,7 @@ from wagtail.search.queryset import SearchableQuerySetMixin
 
 from wagtailvideos import ffmpeg
 
-if wagtail.__version__ >= '2.7':
+if version.parse(wagtail.__version__) >= version.parse('2.7'):
     from wagtail.admin.models import get_object_usage
 else:
     from wagtail.admin.utils import get_object_usage

--- a/wagtailvideos/templates/wagtailvideos/videos/index.html
+++ b/wagtailvideos/templates/wagtailvideos/videos/index.html
@@ -22,9 +22,8 @@
 {% block content %}
     {% trans "Videos" as video_str %}
 
-    {% trans "Add videos" as add_video_str %}
-    {% url "wagtailvideos:add_multiple" as action_url %}
-    {% include "wagtailadmin/shared/header.html" with title=video_str action_icon="media" action_text=add_video_str search_url="wagtailvideos:index" %}
+    {% trans "Add a video" as add_video_str %}
+    {% include "wagtailadmin/shared/header.html" with title=video_str add_link="wagtailvideos:add_multiple" icon="media" add_text=add_video_str search_url="wagtailvideos:index" %}
 
     <div class="nice-padding">
         {% if collections %}

--- a/wagtailvideos/templates/wagtailvideos/videos/index.html
+++ b/wagtailvideos/templates/wagtailvideos/videos/index.html
@@ -22,8 +22,9 @@
 {% block content %}
     {% trans "Videos" as video_str %}
 
-    {% trans "Add a video" as add_video_str %}
-    {% include "wagtailadmin/shared/header.html" with title=video_str add_link="wagtailvideos:add_multiple" icon="media" add_text=add_video_str search_url="wagtailvideos:index" %}
+    {% trans "Add videos" as add_video_str %}
+    {% url "wagtailvideos:add_multiple" as action_url %}
+    {% include "wagtailadmin/shared/header.html" with title=video_str action_icon="media" action_text=add_video_str search_url="wagtailvideos:index" %}
 
     <div class="nice-padding">
         {% if collections %}

--- a/wagtailvideos/views/chooser.py
+++ b/wagtailvideos/views/chooser.py
@@ -1,4 +1,5 @@
 import wagtail
+from packaging import version
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -12,7 +13,7 @@ from wagtailvideos.forms import get_video_form
 from wagtailvideos.models import Video
 from wagtailvideos.permissions import permission_policy
 
-if wagtail.__version__ >= '2.7':
+if version.parse(wagtail.__version__) >= version.parse('2.7'):
     from wagtail.admin.models import popular_tags_for_model
     from wagtail.admin.auth import PermissionPolicyChecker
 else:

--- a/wagtailvideos/views/multiple.py
+++ b/wagtailvideos/views/multiple.py
@@ -1,4 +1,5 @@
 import wagtail
+from packaging import version
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.template.loader import render_to_string
@@ -11,7 +12,7 @@ from wagtailvideos.forms import get_video_form
 from wagtailvideos.models import Video
 from wagtailvideos.permissions import permission_policy
 
-if wagtail.__version__ >= '2.7':
+if version.parse(wagtail.__version__) >= version.parse('2.7'):
     from wagtail.admin.auth import PermissionPolicyChecker
 else:
     from wagtail.admin.utils import PermissionPolicyChecker

--- a/wagtailvideos/views/videos.py
+++ b/wagtailvideos/views/videos.py
@@ -1,4 +1,5 @@
 import wagtail
+from packaging import version
 from django.core.paginator import Paginator
 from django.http import HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, redirect, render
@@ -15,7 +16,7 @@ from wagtailvideos.forms import VideoTranscodeAdminForm, get_video_form
 from wagtailvideos.models import Video
 from wagtailvideos.permissions import permission_policy
 
-if wagtail.__version__ >= '2.7':
+if version.parse(wagtail.__version__) >= version.parse('2.7'):
     from wagtail.admin.models import popular_tags_for_model
     from wagtail.admin.auth import PermissionPolicyChecker
 else:


### PR DESCRIPTION
Changed to use packaging.version to compare version numbers (because string comparison means 2.10 > 2.7 is not True)