### PR TITLE
Fix mimetype when the URL has params

### DIFF
--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -171,6 +171,11 @@ class AbstractVideo(CollectionMember, index.Indexed, models.Model):
     @property
     def file_ext(self):
         return os.path.splitext(self.filename())[1][1:]
+    
+    @property
+    def content_type(self):
+        mime = mimetypes.MimeTypes()
+        mimetype = mime.guess_type(self.url)[0] or mime.guess_type(self.filename())[0]
 
     def is_editable_by_user(self, user):
         from wagtailvideos.permissions import permission_policy
@@ -199,7 +204,7 @@ class AbstractVideo(CollectionMember, index.Indexed, models.Model):
 
         mime = mimetypes.MimeTypes()
         sources.append("<source src='{0}' type='{1}'>"
-                       .format(self.url, mime.guess_type(self.url)[0]))
+                       .format(self.url, self.content_type))
 
         sources.append("<p>Sorry, your browser doesn't support playback for this video</p>")
 

--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -171,11 +171,11 @@ class AbstractVideo(CollectionMember, index.Indexed, models.Model):
     @property
     def file_ext(self):
         return os.path.splitext(self.filename())[1][1:]
-    
+
     @property
     def content_type(self):
         mime = mimetypes.MimeTypes()
-        mimetype = mime.guess_type(self.url)[0] or mime.guess_type(self.filename())[0]
+        return mime.guess_type(self.url)[0] or mime.guess_type(self.filename())[0]
 
     def is_editable_by_user(self, user):
         from wagtailvideos.permissions import permission_policy
@@ -202,7 +202,6 @@ class AbstractVideo(CollectionMember, index.Indexed, models.Model):
         for transcode in transcodes:
             sources.append("<source src='{0}' type='video/{1}' >".format(transcode.url, transcode.media_format.name))
 
-        mime = mimetypes.MimeTypes()
         sources.append("<source src='{0}' type='{1}'>"
                        .format(self.url, self.content_type))
 


### PR DESCRIPTION
Using Cloud Storage could generate urls like:

`https://storage.googleapis.com/<BUCKET_NAME>/<PATH>/test.webm?Expires=1612931745&GoogleAccessId=<ACCOUNT>&Signature=<SIGNATURE>`

Passing parameters to the URL returns `None` in `mime.guess_type(url)`

I'm also extracting the mimetype to some property that can be reused. Similar to https://github.com/wagtail/wagtail/blob/master/wagtail/documents/models.py#L170