### PR TITLE
Make generated thumbnail the size & aspect ratio of the input video

### DIFF
--- a/wagtailvideos/ffmpeg.py
+++ b/wagtailvideos/ffmpeg.py
@@ -60,7 +60,7 @@ def get_thumbnail(file_path):
                 '-vcodec', 'mjpeg',
                 '-vframes', '1',
                 '-an', '-f', 'rawvideo',
-                '-vf', 'scale=iw:-1', # Make thumbnail the size & aspect ratio of the input video
+                '-vf', 'scale=iw:-1',  # Make thumbnail the size & aspect ratio of the input video
                 output_file,
             ], stdin=DEVNULL(), stdout=DEVNULL())
         except subprocess.CalledProcessError:

--- a/wagtailvideos/ffmpeg.py
+++ b/wagtailvideos/ffmpeg.py
@@ -60,7 +60,7 @@ def get_thumbnail(file_path):
                 '-vcodec', 'mjpeg',
                 '-vframes', '1',
                 '-an', '-f', 'rawvideo',
-                '-s', '320x240',
+                '-vf', 'scale=iw:-1', # Make thumbnail the size & aspect ratio of the input video
                 output_file,
             ], stdin=DEVNULL(), stdout=DEVNULL())
         except subprocess.CalledProcessError:


### PR DESCRIPTION
Given we use the generated thumbnail as the default poster in the `video` template tag (which people will use on user facing websites), it should probably respect the aspect ratio of the video. This stops a visible aspect ratio shift when clicking play on a video. `320x240` is also pretty small these days, so I thought using the natural size of the video would be better.