### PR TITLE
Transcode audio instead of copy

### DIFF
--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -42,7 +42,7 @@ class VideoQuality(ChoiceEnum):
 
 class MediaFormats(ChoiceEnum):
     webm = 'VP8 and Vorbis in WebM'
-    mp4 = 'H.264 and MP3 in Mp4'
+    mp4 = 'H.264 and AAC in Mp4'
     ogg = 'Theora and Vorbis in Ogg'
 
     def get_quality_param(self, quality):
@@ -279,7 +279,7 @@ class TranscodingThread(threading.Thread):
                     '-codec:v', 'libx264',
                     '-preset', 'slow',  # TODO Checkout other presets
                     '-crf', quality_param,
-                    '-codec:a', 'copy',
+                    '-codec:a', 'aac',
                     output_file,
                 ], stdin=FNULL, stderr=subprocess.STDOUT)
             elif media_format is MediaFormats.webm:


### PR DESCRIPTION
Currently we copy the audio from the source file into the destination video container. Not all audio codecs are compatible with MP4. To increase the chance a conversion will be successful this PR transcodes the audio into AAC format which is compatible with MP4.