### PR TITLE
Fix modal tab navigation for wagtail 2.13

### DIFF
--- a/wagtailvideos/templates/wagtailvideos/chooser/chooser.html
+++ b/wagtailvideos/templates/wagtailvideos/chooser/chooser.html
@@ -3,7 +3,7 @@
 {% include "wagtailadmin/shared/header.html" with title=choose_str merged=1 tabbed=1 icon="media" %}
 
 {% if uploadform %}
-    <ul class="tab-nav merged">
+    <ul class="tab-nav merged" data-tab-nav>
         <li class="{% if not uploadform.errors %}active{% endif %}"><a href="#search" >{% trans "Search" %}</a></li>
         <li class="{% if uploadform.errors %}active{% endif %}"><a href="#upload">{% trans "Upload" %}</a></li>
     </ul>


### PR DESCRIPTION
Tab navigation in the chooser modal fails in Wagtail 2.13 due to a change (see https://github.com/wagtail/wagtail/commit/ca0154543aa79b463acf4a58ab45ccd8b8f6bd49) that selects the navigation element by a `data-tab-nav` attribute, rather than the `tab-nav` class. This adds the attribute to the chooser template, fixing the navigation. 

See also https://github.com/torchbox/wagtailmedia/issues/129