### PR TITLE
Remove usage of usage_count_enabled template tag

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -15,6 +15,5 @@ INSTALLED_APPS += [
 ]
 
 WAGTAILVIDEOS_VIDEO_MODEL = 'app.CustomVideoModel'
-WAGTAIL_USAGE_COUNT_ENABLED = True
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -221,8 +221,7 @@ class TestVideoEditView(TestCase, WagtailTestUtils):
         # Ensure the form supports file uploads
         self.assertContains(response, 'enctype="multipart/form-data"')
 
-    @override_settings(WAGTAIL_USAGE_COUNT_ENABLED=True)
-    def test_with_usage_count(self):
+    def test_usage_count(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailvideos/videos/edit.html')

--- a/wagtailvideos/templates/wagtailvideos/videos/edit.html
+++ b/wagtailvideos/templates/wagtailvideos/videos/edit.html
@@ -67,13 +67,10 @@
                     <dt>{% trans "Duration" %}</dt>
                     <dd>{{ video.formatted_duration }}</dd>
                     {% endif %}
-                    {% usage_count_enabled as uc_enabled %}
-                    {% if uc_enabled %}
-                        <dt>{% trans "Usage" %}</dt>
-                        <dd>
-                            <a href="{{ video.usage_url }}">{% blocktrans count usage_count=video.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                        </dd>
-                    {% endif %}
+                    <dt>{% trans "Usage" %}</dt>
+                    <dd>
+                        <a href="{{ video.usage_url }}">{% blocktrans count usage_count=video.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                    </dd>
                 </dl>
             </div>
         </div>


### PR DESCRIPTION
Remove usage of `usage_count_enabled` template tag since this tag was removed in Wagtail 4.1
