### PR TITLE
Add ability to generate thumbnail in different formats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Requirements
 ------------
 
 -  Wagtail >= 4.0 (for older wagtail version see the tags)
--  `ffmpeg <https://ffmpeg.org/>`__ 
+-  `ffmpeg <https://ffmpeg.org/>`__
 
 Installing
 ----------
@@ -31,7 +31,7 @@ Add `wagtailvideos` to your installed apps.
     INSTALLED_APPS = [
         'wagtailvideos',
     ]
-    
+
 Using
 -----
 
@@ -120,6 +120,16 @@ Transcode can be disabled using the ``WAGTAIL_VIDEOS_DISABLE_TRANSCODE`` setting
 
     # settings.py
     WAGTAIL_VIDEOS_DISABLE_TRANSCODE = True
+
+Modify Thumbnail extension:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The automatically generated Thumbnail extension can be modified  using the ``WAGTAIL_VIDEOS_THUMBNAIL_EXTENSION`` setting. Default value is jpg
+
+.. code:: django
+
+    # settings.py
+    WAGTAIL_VIDEOS_THUMBNAIL_EXTENSION = 'webp'
 
 Custom Video models:
 ~~~~~~~~~~~~~~~~~~~~

--- a/wagtailvideos/ffmpeg.py
+++ b/wagtailvideos/ffmpeg.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 
 from django.core.files.base import ContentFile
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,8 @@ def get_thumbnail(file_path):
         raise RuntimeError('ffmpeg is not installed')
 
     file_name = os.path.basename(file_path)
-    thumb_name = '{}_thumb{}'.format(os.path.splitext(file_name)[0], '.jpg')
+    thumb_extension = getattr(settings, 'WAGTAIL_VIDEOS_THUMBNAIL_EXTENSION', 'jpg').lower()
+    thumb_name = '{}_thumb.{}'.format(os.path.splitext(file_name)[0], thumb_extension)
 
     try:
         output_dir = tempfile.mkdtemp()
@@ -57,9 +59,9 @@ def get_thumbnail(file_path):
                 '-v', 'quiet',
                 '-itsoffset', '-4',
                 '-i', file_path,
-                '-vcodec', 'mjpeg',
+                '-update', 'true',
                 '-vframes', '1',
-                '-an', '-f', 'rawvideo',
+                '-an',
                 '-vf', 'scale=iw:-1',  # Make thumbnail the size & aspect ratio of the input video
                 output_file,
             ], stdin=DEVNULL(), stdout=DEVNULL())


### PR DESCRIPTION
Fix #100

Now it would be possible to specify the extension of the generated thumbnail using `WAGTAIL_VIDEOS_THUMBNAIL_EXTENSION`