### PR TITLE
feat: delete transcodes from the admin view

### DIFF
--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -700,6 +700,7 @@ class TestMultipleVideoUploader(TestCase, WagtailTestUtils):
         self.assertEqual(response_json["video_id"], self.video.id)
         self.assertTrue(response_json["success"])
 
+
 @override_settings(WAGTAILVIDEOS_VIDEO_MODEL="wagtailvideos.Video")
 class TestDeleteTranscode(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -11,7 +11,8 @@ from wagtail.models import Collection, GroupCollectionPermission
 from wagtail.test.utils import WagtailTestUtils
 
 from tests.utils import create_test_video_file
-from wagtailvideos.models import Video
+from wagtailvideos.enums import MediaFormats
+from wagtailvideos.models import Video, VideoTranscode
 
 
 class TestVideoIndexView(WagtailTestUtils, TestCase):
@@ -698,3 +699,38 @@ class TestMultipleVideoUploader(TestCase, WagtailTestUtils):
         self.assertIn("success", response_json)
         self.assertEqual(response_json["video_id"], self.video.id)
         self.assertTrue(response_json["success"])
+
+@override_settings(WAGTAILVIDEOS_VIDEO_MODEL="wagtailvideos.Video")
+class TestDeleteTranscode(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+        # Create a video to edit
+        self.video = Video.objects.create(
+            title="Test video",
+            file=create_test_video_file()
+        )
+
+        # Create a transcode to delete
+        self.video.transcodes.create(
+            media_format=MediaFormats.MP4,
+            file=create_test_video_file()
+        )
+
+    def get(self, transcode_id, params={}):
+        return self.client.get(
+            reverse("wagtailvideos:delete_transcode", args=(self.video.id, transcode_id)),
+            params
+        )
+
+    def test_delete(self):
+        transcode = self.video.transcodes.first()
+        self.assertIsNotNone(transcode)
+
+        response = self.get(transcode.id)
+
+        # Should redirect back to edit view
+        self.assertRedirects(response, reverse("wagtailvideos:edit", args=(self.video.id,)))
+
+        # Should delete the transcode
+        self.assertFalse(VideoTranscode.objects.filter(id=transcode.id).exists())

--- a/wagtailvideos/templates/wagtailvideos/videos/edit.html
+++ b/wagtailvideos/templates/wagtailvideos/videos/edit.html
@@ -84,6 +84,10 @@
                         {% endblocktrans %}
                     {% if transcode.file %}
                         </a>
+                        <span>-</span>
+                        <a href="{% url 'wagtailvideos:delete_transcode' video.id transcode.id %}">
+                            {% trans "delete" %}
+                        </a>
                     {% endif %}
                     {% if transcode.processing %}
                         <span class="processing">{% trans "(Processing... hold tight)" %} </span>

--- a/wagtailvideos/urls.py
+++ b/wagtailvideos/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
 
     re_path(r'^(\d+)/delete/$', videos.delete, name='delete'),
     re_path(r'^(\d+)/create_transcode/$', videos.create_transcode, name='create_transcode'),
+    re_path(r'^(\d+)/delete_transcode/(\d+)$', videos.delete_transcode, name='delete_transcode'),
     re_path(r'^(\d+)/$', videos.edit, name='edit'),
     path('', videos.IndexView.as_view(), name='index'),
     path("results/", videos.IndexView.as_view(results_only=True), name="index_results"),

--- a/wagtailvideos/views/videos.py
+++ b/wagtailvideos/views/videos.py
@@ -123,6 +123,11 @@ def create_transcode(request, video_id):
         transcode_form.save()
     return redirect('wagtailvideos:edit', video_id)
 
+@permission_checker.require('delete')
+def delete_transcode(request, video_id, transcode_id):
+    video = get_object_or_404(get_video_model(), id=video_id)
+    video.transcodes.filter(id=transcode_id).delete()
+    return redirect('wagtailvideos:edit', video_id)
 
 @permission_checker.require('delete')
 def delete(request, video_id):

--- a/wagtailvideos/views/videos.py
+++ b/wagtailvideos/views/videos.py
@@ -123,11 +123,13 @@ def create_transcode(request, video_id):
         transcode_form.save()
     return redirect('wagtailvideos:edit', video_id)
 
+
 @permission_checker.require('delete')
 def delete_transcode(request, video_id, transcode_id):
     video = get_object_or_404(get_video_model(), id=video_id)
     video.transcodes.filter(id=transcode_id).delete()
     return redirect('wagtailvideos:edit', video_id)
+
 
 @permission_checker.require('delete')
 def delete(request, video_id):


### PR DESCRIPTION
Resolves #122 

Adds a delete link to each transcode in the video edit admin view. Clicking it will delete the transcode and redirect back to the edit view.

<img width="1458" height="380" alt="23894DDA-C055-430D-AB76-BED373AE5B9C" src="https://github.com/user-attachments/assets/59ec4367-442c-43ef-95a2-dc8bd8b293f0" />
